### PR TITLE
Fix tests inclusion and README link

### DIFF
--- a/BEP - SLSA interpreter/src/main.rs
+++ b/BEP - SLSA interpreter/src/main.rs
@@ -5,6 +5,9 @@ use structopt::StructOpt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+#[cfg(test)]
+mod test_sample;
+
 #[derive(Debug, StructOpt)]
 #[structopt(name = "bep-to-slsa", about = "Transform Bazel BEP data to SLSA provenance format")]
 struct Opt {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This work is foundational to ensuring the safe and accountable use of machine le
 
 - [`llvm_ir_analyzer`](./llvm_ir_analyzer): Static IR-level scanner for unsafe memory patterns (Rust, LLVM IR).
 - [`mlir_audit_tool`](./mlir_audit_tool): MLIR dialect-aware audit tool for dynamic ops and layout violations (Rust, MLIR).
-- [`bep_to_slsa`](BEP - SLSA interpreter](https://github.com/agshipley/NLSAFE/tree/3346b48752764fbfe6e8f384dc799763fd092ac0/BEP%20-%20SLSA%20interpreter): Transformer that converts Bazel Build Event Protocol (BEP) data into SLSA provenance format for cryptographically verifiable build records (Rust).
+- [`bep_to_slsa`](./BEP%20-%20SLSA%20interpreter): Transformer that converts Bazel Build Event Protocol (BEP) data into SLSA provenance format for cryptographically verifiable build records (Rust).
 
 ## 📊 Project Tracker
 


### PR DESCRIPTION
## Summary
- ensure BEP to SLSA interpreter tests are compiled by adding module include
- fix malformed link in README

## Testing
- `cargo test --quiet` *(fails: could not download crates)*
- `cargo test --quiet` in llvm_ir_analyzer
- `cargo test --quiet` in mlir_audit_tool